### PR TITLE
feat: Optimize rendering with pre-baked glyph atlas

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -14,7 +14,6 @@ char *find_font_path_from_fc_name(const char *font_name)
 
     FcPattern *pattern = FcNameParse((const FcChar8 *)font_name);
     FcConfigSubstitute(NULL, pattern, FcMatchPattern);
-    FcPatternAddInteger(pattern, FC_WEIGHT, FC_WEIGHT_DEMIBOLD);
     FcDefaultSubstitute(pattern);
 
     FcResult result;

--- a/src/pretty.c
+++ b/src/pretty.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
     }
 
     glyph_atlas *atlas = create_atlas(renderer, font.ttf, config);
-    if (!atlas) {
+    if (atlas == NULL) {
         pretty_log(PRETTY_ERROR, "Failed to bake glyph atlas");
         goto quit;
     }
@@ -196,7 +196,6 @@ int main(int argc, char **argv)
                     else pretty_log(PRETTY_DEBUG, "unhandled key: %s", SDL_GetKeyName(event.key.key));
                     break;
                 }
-
                 case SDL_EVENT_MOUSE_WHEEL:
                     if (event.wheel.y > 0) calculate_scroll(&tty, SCROLL_UP);
                     else if (event.wheel.y < 0) calculate_scroll(&tty, SCROLL_DOWN);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -20,6 +20,12 @@ enum event {
 };
 
 typedef struct {
+    SDL_Texture *texture;
+    SDL_FRect glyphs[128];
+    int w, h;
+} glyph_atlas;
+
+typedef struct {
     SDL_Surface *surface;
     SDL_Texture *texture;
     size_t length;
@@ -31,8 +37,10 @@ struct dim {
 };
 
 void display_fps_metrics(SDL_Window *win);
+glyph_atlas* create_atlas(SDL_Renderer *renderer, TTF_Font *font, generic_config *conf);
 bool render_frame(
     SDL_Renderer *renderer,
+    glyph_atlas *atlas,
     struct dim win_size,
     tty_state *tty,
     char *text,


### PR DESCRIPTION
Replace per-frame text surface/texture creation with a pre-rendered glyph atlas, significantly reducing allocation overhead during rendering.

Changes:
- Add glyph_atlas structure to cache rendered glyphs in a single texture
- Pre-render ASCII printable characters (32-126) into 16x8 atlas grid
- Replace TTF_RenderText_Blended with direct texture copies from atlas
- Remove per-character surface/texture allocation in render loop
- Remove FC_WEIGHT_DEMIBOLD override to respect font specification
- Add atlas creation/cleanup in main lifecycle
- Eliminate line_buffer allocation per frame

This reduces render_frame() from creating hundreds of surfaces/textures per frame to simple texture copies, improving performance for terminal rendering workloads.