### PR TITLE
refactor: replace openpty with posix_openpt and decouple PTY logic

### DIFF
--- a/src/pretty.c
+++ b/src/pretty.c
@@ -19,10 +19,12 @@
 #include "config.h"
 #include "macro_utils.h"
 #include "pretty.h"
+#include "signal.h"
 #include "slave.h"
 #include "font.h"
 #include "renderer.h"
 #include "log.h"
+#include "terminal.h"
 
 #define SCREEN_WIDTH 1280
 #define SCREEN_HEIGHT 720
@@ -41,16 +43,20 @@ void notify_ui_flush(void)
     SDL_PushEvent(&ev);
 }
 
-void thread_handle_quit(tty_state *tty)
+void thread_handle_quit(pty_session *pty)
 {
-    tty->should_exit = true;
-    pretty_log(PRETTY_DEBUG, "waiting for thread [%lu] to exit", tty->thread);
+    pty->should_exit = true;
+    pretty_log(PRETTY_DEBUG, "waiting for thread [%lu] to exit", pty->thread);
+
+    if (pthread_kill(pty->thread, SIGUSR1) != 0) {
+        pretty_log(PRETTY_ERROR, "failed to send signal to thread");
+    }
 
     void *res;
-    int s = pthread_join(tty->thread, &res);
+    int s = pthread_join(pty->thread, &res);
 
     if (s != 0) pretty_log(PRETTY_ERROR, "pthread_join failed");
-    else pretty_log(PRETTY_DEBUG, "thread [%lu] exited cleanly", tty->thread);
+    else pretty_log(PRETTY_DEBUG, "thread [%lu] exited cleanly", pty->thread);
 }
 
 int main(int argc, char **argv)
@@ -95,16 +101,22 @@ int main(int argc, char **argv)
     char buff[TTY_RING_CAP] = { 0 };
     size_t buff_pos = 0;
 
-    tty_state tty = {
-        .pty_master_fd = tty_new((char *[]){ "/bin/sh", NULL }),
+    term pretty = {
+        .pty = {
+            .io_lock = PTHREAD_MUTEX_INITIALIZER,
+            .child_exited = false
+        },
+        .buffer_lock = PTHREAD_MUTEX_INITIALIZER,
         .buff_changed = false,
-        .lock = PTHREAD_MUTEX_INITIALIZER,
         .overwrite_oldest = true,
         .auto_scroll = true,
-        .child_exited = false,
     };
 
-    if (pthread_create(&tty.thread, NULL, tty_poll_loop, &tty) != 0) return EXIT_FAILURE;
+    if (!pty_pair(&pretty.pty)) die("failed to pair pty");
+
+    if (!pty_init(&pretty.pty)) die("failed to initialize pty");
+
+    if (pthread_create(&pretty.pty.thread, NULL, pty_poll_loop, &pretty) != 0) return EXIT_FAILURE;
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         pretty_log(PRETTY_ERROR, "Couldn't initialize SDL: %s", SDL_GetError());
@@ -171,13 +183,13 @@ int main(int argc, char **argv)
 
                     if (mod & SDL_KMOD_LCTRL) switch (event.key.key) {
                         case SDLK_C:
-                            tty_write(&tty, "\x03", 1);
+                            pty_write(&pretty.pty, "\x03", 1);
                             break;
                         case SDLK_D:
-                            tty_write(&tty, "\x04", 1);
+                            pty_write(&pretty.pty, "\x04", 1);
                             break;
                         case SDLK_Z:
-                            tty_write(&tty, "\x1A", 1);
+                            pty_write(&pretty.pty, "\x1A", 1);
                             break;
                         default:
                             pretty_log(PRETTY_DEBUG, "unhandled key combination: LCtrl+%s",
@@ -186,37 +198,37 @@ int main(int argc, char **argv)
                     }
 
                     else if (event.key.key <= UCHAR_MAX && isprint(event.key.key))
-                        tty_write(&tty, (char *)&event.key.key, sizeof(char));
+                        pty_write(&pretty.pty, (char *)&event.key.key, sizeof(char));
 
                     else if (event.key.key == SDLK_RETURN)
-                        tty_write(&tty, "\r", length_of("\r"));
+                        pty_write(&pretty.pty, "\r", length_of("\r"));
 
                     else if (event.key.key == SDLK_BACKSPACE)
-                        tty_write(&tty, "\x7f", 1);
+                        pty_write(&pretty.pty, "\x7f", 1);
 
                     else pretty_log(PRETTY_DEBUG, "unhandled key: %s", SDL_GetKeyName(event.key.key));
                     break;
                 }
                 case SDL_EVENT_MOUSE_WHEEL:
-                    tty.auto_scroll = false;
-                    if (event.wheel.y > 0) calculate_scroll(&tty, SCROLL_UP);
-                    else if (event.wheel.y < 0) calculate_scroll(&tty, SCROLL_DOWN);
+                    pretty.auto_scroll = false;
+                    if (event.wheel.y > 0) calculate_scroll(&pretty, SCROLL_UP);
+                    else if (event.wheel.y < 0) calculate_scroll(&pretty, SCROLL_DOWN);
 
-                    read_to_buff(&tty, buff, sizeof(buff), &buff_pos);
+                    read_to_buff(&pretty, buff, sizeof(buff), &buff_pos);
                     goto render_frame;
                     break;
                 case SDL_EVENT_USER:
-                    read_to_buff(&tty, buff, sizeof(buff), &buff_pos);
+                    read_to_buff(&pretty, buff, sizeof(buff), &buff_pos);
                     goto render_frame;
 
 render_frame:
-                    if (!render_frame(renderer, atlas, win_size, &tty, buff,
+                    if (!render_frame(renderer, atlas, win_size, &pretty, buff,
                                 sizeof(buff), &buff_pos, &font, config))
                     {
                         is_running = false;
                         continue;
                     }
-                    if (tty.scroll_tail == tty.last_head) tty.auto_scroll = true;
+                    if (pretty.scroll_tail == pretty.last_head) pretty.auto_scroll = true;
                     break;
                 default:
                     break;
@@ -226,9 +238,9 @@ render_frame:
 #endif
         display_fps_metrics(win);
 
-        if (tty.child_exited) {
+        if (pretty.pty.child_exited) {
             is_running = false;
-            tty.should_exit = true;
+            pretty.pty.should_exit = true;
         }
     }
 
@@ -236,7 +248,7 @@ render_frame:
     free(atlas);
 
 quit:
-    thread_handle_quit(&tty);
+    thread_handle_quit(&pretty.pty);
     TTF_CloseFont(font.ttf);
     TTF_Quit();
     SDL_DestroyWindow(win);

--- a/src/pretty.c
+++ b/src/pretty.c
@@ -1,13 +1,16 @@
-#include <ctype.h>
+#include <SDL3/SDL_rect.h>
+#include <SDL3/SDL_timer.h>
 #include <getopt.h>
 #include <limits.h>
 #include <pthread.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/eventfd.h>
+#include <sys/ioctl.h>
 
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_pixels.h>
@@ -28,8 +31,6 @@
 
 #define SCREEN_WIDTH 1280
 #define SCREEN_HEIGHT 720
-
-#define TEST_COMMAND "python tests/plop.py\r"
 
 static struct option LONG_OPTIONS[] = {
     {"config", required_argument, 0, 'c'},
@@ -112,14 +113,13 @@ int main(int argc, char **argv)
         .buffer_lock = PTHREAD_MUTEX_INITIALIZER,
         .buff_changed = false,
         .overwrite_oldest = true,
-        .auto_scroll = true,
+        .cursor_col = 0,
+        .cursor_row = 0
     };
 
     if (!pty_pair(&pretty.pty)) die("failed to pair pty");
 
     if (!pty_init(&pretty.pty)) die("failed to initialize pty");
-
-    if (pthread_create(&pretty.pty.thread, NULL, pty_poll_loop, &pretty) != 0) return EXIT_FAILURE;
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         pretty_log(PRETTY_ERROR, "Couldn't initialize SDL: %s", SDL_GetError());
@@ -142,6 +142,16 @@ int main(int argc, char **argv)
         return SDL_APP_FAILURE;
     }
 
+    SDL_DisplayID display = SDL_GetPrimaryDisplay();
+    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(display);
+
+    thread_args args = {
+        .pretty = &pretty,
+        .notify_interval = 1000 / mode->refresh_rate,
+    };
+
+    if (pthread_create(&pretty.pty.thread, NULL, pty_poll_loop, &args) != 0) return EXIT_FAILURE;
+
     SDL_SetRenderDrawColor(renderer,
         HEX_TO_RGBA(config->color_palette[COLOR_BACKGROUND]));
 #ifdef WAIT_EVENTS
@@ -160,14 +170,17 @@ int main(int argc, char **argv)
         goto quit;
     }
 
+    Grid grid;
+    grid.cells = calloc(SCREEN_HEIGHT * SCREEN_WIDTH, sizeof(Cell));
+    grid.rows = SCREEN_HEIGHT;
+    grid.cols = SCREEN_WIDTH;
+
+    SDL_StartTextInput(win);
+    SDL_SetRenderVSync(renderer, 1);
+
     for (bool is_running = true; is_running;) {
-        SDL_StartTextInput(win);
         SDL_Event event;
-#ifdef WAIT_EVENTS
-        SDL_WaitEvent(&event);
-#else
         for (; SDL_PollEvent(&event); ) {
-#endif
             switch (event.type) {
                 case SDL_EVENT_QUIT:
                     is_running = false;
@@ -175,12 +188,17 @@ int main(int argc, char **argv)
                 case SDL_EVENT_WINDOW_RESIZED:
                     win_size.width = event.window.data1;
                     win_size.height = event.window.data2;
-                    pretty_log(PRETTY_INFO, "Window resized: %dx%d",
-                            win_size.width, win_size.height);
-                    goto render_frame;
+
+                    int new_cols = win_size.width / atlas->w;
+                    int new_rows = win_size.height / atlas->h;
+
+                    grid_resize(&grid, new_rows, new_cols);
+
+                    if (pretty.cursor_col >= grid.cols) pretty.cursor_col = grid.cols - 1;
+                    if (pretty.cursor_row >= grid.rows) pretty.cursor_row = grid.rows - 1;
+
                     break;
                 case SDL_EVENT_WINDOW_EXPOSED:
-                    goto render_frame;
                     break;
                 case SDL_EVENT_TEXT_INPUT: {
                     const char *text = event.text.text;
@@ -216,33 +234,23 @@ int main(int argc, char **argv)
                     break;
                 }
                 case SDL_EVENT_MOUSE_WHEEL:
-                    pretty.auto_scroll = false;
                     if (event.wheel.y > 0) calculate_scroll(&pretty, SCROLL_UP);
                     else if (event.wheel.y < 0) calculate_scroll(&pretty, SCROLL_DOWN);
 
-                    read_to_buff(&pretty, buff, sizeof(buff), &buff_pos);
-                    goto render_frame;
+                    rebuild_grid_from_buffer(&grid, &pretty, pretty.buff, TTY_RING_CAP);
                     break;
                 case SDL_EVENT_USER:
-                    read_to_buff(&pretty, buff, sizeof(buff), &buff_pos);
-                    goto render_frame;
-
-render_frame:
-                    if (!render_frame(renderer, atlas, win_size, &pretty, buff,
-                                sizeof(buff), &buff_pos, &font, config))
-                    {
-                        is_running = false;
-                        continue;
-                    }
-                    if (pretty.scroll_tail == pretty.last_head) pretty.auto_scroll = true;
+                    process_buffer(&pretty, &grid, buff, &buff_pos, sizeof(buff));
                     break;
                 default:
                     break;
             }
-#ifndef WAIT_EVENTS
         }
-#endif
-        display_fps_metrics(win);
+
+        if (!render_frame(renderer, atlas, &grid, config))
+            is_running = false;
+
+        display_fps_metrics(win, mode);
 
         if (pretty.pty.child_exited) {
             is_running = false;

--- a/src/pretty.c
+++ b/src/pretty.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/eventfd.h>
 
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_pixels.h>
@@ -19,7 +20,6 @@
 #include "config.h"
 #include "macro_utils.h"
 #include "pretty.h"
-#include "signal.h"
 #include "slave.h"
 #include "font.h"
 #include "renderer.h"
@@ -48,8 +48,10 @@ void thread_handle_quit(pty_session *pty)
     pty->should_exit = true;
     pretty_log(PRETTY_DEBUG, "waiting for thread [%lu] to exit", pty->thread);
 
-    if (pthread_kill(pty->thread, SIGUSR1) != 0) {
-        pretty_log(PRETTY_ERROR, "failed to send signal to thread");
+    uint64_t val = 1;
+    if (write(pty->wakeup_fd, &val, sizeof(val)) != sizeof(val)) {
+        pretty_log(PRETTY_ERROR, "writing to wakeup_fd failed, falling back to pthread_cancel");
+        pthread_cancel(pty->thread);
     }
 
     void *res;
@@ -104,7 +106,8 @@ int main(int argc, char **argv)
     term pretty = {
         .pty = {
             .io_lock = PTHREAD_MUTEX_INITIALIZER,
-            .child_exited = false
+            .child_exited = false,
+            .wakeup_fd = eventfd(0, EFD_NONBLOCK)
         },
         .buffer_lock = PTHREAD_MUTEX_INITIALIZER,
         .buff_changed = false,
@@ -158,6 +161,7 @@ int main(int argc, char **argv)
     }
 
     for (bool is_running = true; is_running;) {
+        SDL_StartTextInput(win);
         SDL_Event event;
 #ifdef WAIT_EVENTS
         SDL_WaitEvent(&event);
@@ -178,6 +182,13 @@ int main(int argc, char **argv)
                 case SDL_EVENT_WINDOW_EXPOSED:
                     goto render_frame;
                     break;
+                case SDL_EVENT_TEXT_INPUT: {
+                    const char *text = event.text.text;
+                    unsigned char ch = (unsigned char)text[0];
+
+                    if (ch > 0 && ch < 0x80) pty_write(&pretty.pty, (char *)&ch, sizeof(char));
+                    break;
+                }
                 case SDL_EVENT_KEY_DOWN: {
                     SDL_Keymod mod = SDL_GetModState();
 
@@ -197,16 +208,11 @@ int main(int argc, char **argv)
                             break;
                     }
 
-                    else if (event.key.key <= UCHAR_MAX && isprint(event.key.key))
-                        pty_write(&pretty.pty, (char *)&event.key.key, sizeof(char));
-
                     else if (event.key.key == SDLK_RETURN)
                         pty_write(&pretty.pty, "\r", length_of("\r"));
 
                     else if (event.key.key == SDLK_BACKSPACE)
                         pty_write(&pretty.pty, "\x7f", 1);
-
-                    else pretty_log(PRETTY_DEBUG, "unhandled key: %s", SDL_GetKeyName(event.key.key));
                     break;
                 }
                 case SDL_EVENT_MOUSE_WHEEL:

--- a/src/pretty.c
+++ b/src/pretty.c
@@ -37,30 +37,7 @@ static struct option LONG_OPTIONS[] = {
     {0,        0,                 0,  0 }
 };
 
-void notify_ui_flush(void)
-{
-    static SDL_Event ev = { .type = SDL_EVENT_USER };
-
-    SDL_PushEvent(&ev);
-}
-
-void thread_handle_quit(pty_session *pty)
-{
-    pty->should_exit = true;
-    pretty_log(PRETTY_DEBUG, "waiting for thread [%lu] to exit", pty->thread);
-
-    uint64_t val = 1;
-    if (write(pty->wakeup_fd, &val, sizeof(val)) != sizeof(val)) {
-        pretty_log(PRETTY_ERROR, "writing to wakeup_fd failed, falling back to pthread_cancel");
-        pthread_cancel(pty->thread);
-    }
-
-    void *res;
-    int s = pthread_join(pty->thread, &res);
-
-    if (s != 0) pretty_log(PRETTY_ERROR, "pthread_join failed");
-    else pretty_log(PRETTY_DEBUG, "thread [%lu] exited cleanly", pty->thread);
-}
+static void thread_handle_quit(pty_session *pty);
 
 int main(int argc, char **argv)
 {
@@ -278,4 +255,23 @@ quit:
     pretty_log(PRETTY_INFO, "Succesfully closed Pretty instance");
 
     return EXIT_SUCCESS;
+}
+
+static
+void thread_handle_quit(pty_session *pty)
+{
+    pty->should_exit = true;
+    pretty_log(PRETTY_INFO, "waiting for thread [%lu] to exit", pty->thread);
+
+    uint64_t val = 1;
+    if (write(pty->wakeup_fd, &val, sizeof(val)) != sizeof(val)) {
+        pretty_log(PRETTY_ERROR, "writing to wakeup_fd failed, falling back to pthread_cancel");
+        pthread_cancel(pty->thread);
+    }
+
+    void *res;
+    int s = pthread_join(pty->thread, &res);
+
+    if (s != 0) pretty_log(PRETTY_ERROR, "pthread_join failed");
+    else pretty_log(PRETTY_INFO, "thread [%lu] exited cleanly", pty->thread);
 }

--- a/src/pretty.c
+++ b/src/pretty.c
@@ -170,10 +170,13 @@ int main(int argc, char **argv)
         goto quit;
     }
 
+    int available_width = SCREEN_WIDTH - (2 * config->pad_x);
+    int available_height = SCREEN_HEIGHT - (2 * config->pad_y);
+
     Grid grid;
-    grid.cells = calloc(SCREEN_HEIGHT * SCREEN_WIDTH, sizeof(Cell));
-    grid.rows = SCREEN_HEIGHT;
-    grid.cols = SCREEN_WIDTH;
+    grid.rows = available_height / atlas->h;
+    grid.cols = available_width / atlas->w;
+    grid.cells = calloc(grid.rows * grid.cols, sizeof(Cell));
 
     SDL_StartTextInput(win);
     SDL_SetRenderVSync(renderer, 1);
@@ -189,8 +192,11 @@ int main(int argc, char **argv)
                     win_size.width = event.window.data1;
                     win_size.height = event.window.data2;
 
-                    int new_cols = win_size.width / atlas->w;
-                    int new_rows = win_size.height / atlas->h;
+                    available_width = win_size.width - (2 * config->pad_x);
+                    available_height = win_size.height - (2 * config->pad_y);
+
+                    int new_cols = available_width / atlas->w;
+                    int new_rows = available_height / atlas->h;
 
                     grid_resize(&grid, new_rows, new_cols);
 

--- a/src/pretty.h
+++ b/src/pretty.h
@@ -30,7 +30,5 @@ typedef struct {
 } thread_args;
 
 char *file_read(char const *filepath);
-void notify_ui_flush(void);
-
 
 #endif

--- a/src/pretty.h
+++ b/src/pretty.h
@@ -6,6 +6,8 @@
     #include <stdarg.h>
 
     #include "log.h"
+    #include "terminal.h"
+    #include "stdint.h"
 
 static inline __attribute__((format(printf, 1, 2)))
 void die(const char *errstr, ...)
@@ -21,6 +23,11 @@ void die(const char *errstr, ...)
 
     exit(EXIT_FAILURE);
 }
+
+typedef struct {
+    term *pretty;
+    uint64_t notify_interval;
+} thread_args;
 
 char *file_read(char const *filepath);
 void notify_ui_flush(void);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -124,29 +124,37 @@ void rebuild_grid_from_buffer(Grid *grid, term *pretty, char *ring_buffer, size_
     while (pos != pretty->head && row < grid->rows) {
         char ch = ring_buffer[pos];
 
-        if (ch == '\n') {
-            row++;
-            col = 0;
-        } else if (ch == '\r') {
-            col = 0;
-        } else if (ch == '\b' || ch == 0x7f) {
-            if (col > 0) {
-                col--;
-                grid->cells[row * grid->cols + col].ch = ' ';
-            } else if (row > 0) {
-                row--;
-                col = grid->cols - 1;
-                grid->cells[row * grid->cols + col].ch = ' ';
-            }
-        } else if (ch >= ' ' && ch <= '~') {
-            if (col >= grid->cols) {
+        switch (ch) {
+            case '\n':
                 row++;
                 col = 0;
-                if (row >= grid->rows) break;
-            }
+                break;
+            case '\r':
+                col = 0;
+                break;
+            case '\b':
+            case 0x7f:
+                if (col > 0) {
+                    col--;
+                    grid->cells[row * grid->cols + col].ch = ' ';
+                } else if (row > 0) {
+                    row--;
+                    col = grid->cols - 1;
+                    grid->cells[row * grid->cols + col].ch = ' ';
+                }
+                break;
+            default:
+                if (ch >= ' ' && ch <= '~') {
+                    if (col >= grid->cols) {
+                        row++;
+                        col = 0;
+                        if (row >= grid->rows) break;
+                    }
 
-            grid->cells[row * grid->cols + col].ch = ch;
-            col++;
+                    grid->cells[row * grid->cols + col].ch = ch;
+                    col++;
+                }
+                break;
         }
         pos = (pos + 1) % ring_size;
     }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -6,13 +6,10 @@
 #include "SDL3_ttf/SDL_ttf.h"
 #include "macro_utils.h"
 #include "renderer.h"
-#include "log.h"
 #include "pthread.h"
 #include "slave.h"
-
-static const char *event_name[] = {
-    FOREACH_EVENT(GENERATE_STRING)
-};
+#include "terminal.h"
+#include "pretty.h"
 
 void display_fps_metrics(SDL_Window *win)
 {
@@ -88,66 +85,18 @@ glyph_atlas *create_atlas(SDL_Renderer *renderer, TTF_Font *font, generic_config
     return atlas;
 }
 
-static void calculate_scroll_internal(tty_state *tty, enum event dir)
-{
-    switch (dir) {
-        case SCROLL_UP: {
-            if (tty->scroll_tail == 0) break;
-
-            size_t pos = (tty->scroll_tail + TTY_RING_CAP - 1) % TTY_RING_CAP;
-
-            while (pos != 0 && tty->buff[pos] != '\n')
-                pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
-
-            if (tty->buff[pos] == '\n' && pos != 0) {
-                pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
-
-                while (pos != 0 && tty->buff[pos] != '\n')
-                    pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
-
-                if (tty->buff[pos] == '\n') pos = (pos + 1) % TTY_RING_CAP;
-            }
-
-            tty->scroll_tail = pos;
-
-            break;
-        }
-        case SCROLL_DOWN: {
-            if (tty->scroll_tail == tty->head) break;
-
-            size_t pos = tty->scroll_tail;
-            while (pos != tty->head && tty->buff[pos] != '\n')
-                pos = (pos + 1) % TTY_RING_CAP;
-
-            if (pos != tty->head && tty->buff[pos] == '\n')
-                pos = (pos + 1) % TTY_RING_CAP;
-
-            if (pos != tty->head) tty->scroll_tail = pos;
-
-            break;
-        }
-        default:
-            pthread_mutex_unlock(&tty->lock);
-            pretty_log(PRETTY_ERROR, "unhandled scroll event %d", dir);
-            return;
-    }
-
-    pretty_log(PRETTY_DEBUG, "scroll: event=%s, scroll_tail=%zu tail=%zu head=%zu",
-            event_name[dir], tty->scroll_tail, tty->tail, tty->head);
-}
-
 bool render_frame(
     SDL_Renderer *renderer,
     glyph_atlas *atlas,
     struct dim win_size,
-    tty_state *tty,
+    term *pretty,
     char *text,
     size_t buff_size,
     size_t *buff_pos,
     font_info *font,
     generic_config *conf)
 {
-    pthread_mutex_lock(&tty->lock);
+    pthread_mutex_lock(&pretty->buffer_lock);
 
     SDL_Color bg = { HEX_TO_RGB(conf->color_palette[COLOR_BACKGROUND]), .a=255 };
     SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
@@ -160,7 +109,7 @@ bool render_frame(
     size_t line_max_width = (win_size.width - (2 * x)) / font->advance;
     size_t line_max_count= (win_size.height - (2 * y)) / font->line_skip;
 
-    size_t pos = tty->scroll_tail;
+    size_t pos = pretty->scroll_tail;
     size_t line_count = 0;
 
     while (pos != *buff_pos && line_count < line_max_count) {
@@ -197,60 +146,11 @@ bool render_frame(
 
     }
 
-    if (tty->auto_scroll && line_count >= line_max_count && pos != *buff_pos)
-        calculate_scroll_internal(tty, SCROLL_DOWN);
+    if (pretty->auto_scroll && line_count >= line_max_count && pos != *buff_pos)
+        calculate_scroll_internal(pretty, SCROLL_DOWN);
 
     SDL_RenderPresent(renderer);
-    pthread_mutex_unlock(&tty->lock);
+    pthread_mutex_unlock(&pretty->buffer_lock);
 
     return true;
-}
-
-
-void calculate_scroll(tty_state *tty, enum event dir)
-{
-    pthread_mutex_lock(&tty->lock);
-    calculate_scroll_internal(tty, dir);
-    pthread_mutex_unlock(&tty->lock);
-}
-
-void read_to_buff(
-    tty_state *tty,
-    char *buff,
-    size_t buff_size,
-    size_t *buff_pos)
-{
-    pthread_mutex_lock(&tty->lock);
-
-    const char *p;
-    size_t new_bytes = ring_read_span(tty, &p);
-
-    if (new_bytes) {
-        pretty_log(PRETTY_INFO, "Processing %zu new bytes (consumed: %zu, total: %zu)",
-           new_bytes, tty->tail, tty->head);
-
-        for (size_t i = 0; i < new_bytes; i++) {
-            char ch = p[i];
-
-            if (ch == '\b' || ch == 0x7f) {
-                if (*buff_pos > 0) {
-                    (*buff_pos)--;
-                    pretty_log(PRETTY_INFO, "Backspace: removed char at position %zu", *buff_pos);
-                    buff[*buff_pos] = '\0';
-                }
-            } else if (*buff_pos < buff_size - 1) {
-                buff[(*buff_pos)++] = ch;
-                buff[*buff_pos] = '\0';
-                pretty_log(PRETTY_INFO, "Added char '%c' at position %zu",
-                    (isprint(ch)) ? ch : '?', *buff_pos - 1);
-            }
-
-            if (*buff_pos >= buff_size - 1) {
-                pretty_log(PRETTY_WARN, "buff_pos overflow, resseting");
-                *buff_pos = 0;
-            }
-        }
-        ring_consume(tty, new_bytes);
-    }
-    pthread_mutex_unlock(&tty->lock);
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -193,3 +193,10 @@ bool render_frame(
     SDL_RenderPresent(renderer);
     return true;
 }
+
+void notify_ui_flush(void)
+{
+    static SDL_Event ev = { .type = SDL_EVENT_USER };
+
+    SDL_PushEvent(&ev);
+}

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,4 +1,3 @@
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -6,26 +5,29 @@
 #include "SDL3_ttf/SDL_ttf.h"
 #include "macro_utils.h"
 #include "renderer.h"
-#include "pthread.h"
 #include "slave.h"
+#include "log.h"
 #include "terminal.h"
-#include "pretty.h"
 
-void display_fps_metrics(SDL_Window *win)
+void display_fps_metrics(SDL_Window *win, const SDL_DisplayMode *mode)
 {
-    static unsigned short frames = 0;
-    static Uint64 last_time = 0;
+    static unsigned int frame_count = 0;
+    static uint64_t last_time = 0;
 
-    frames++;
-    Uint64 current_time = SDL_GetTicks();
+    frame_count++;
+    uint64_t current_time = SDL_GetTicks();
+    uint64_t elapsed = current_time - last_time;
 
-    if (current_time - last_time >= 1000) {
-        char title[length_of("Pretty | ...... fps")];
+    if (elapsed >= 1000) {
+        float actual_fps = (float)frame_count / (elapsed / 1000.0f);
 
-        snprintf(title, sizeof title, "Pretty | %6hu fps", frames);
+        char title[64];
+        snprintf(title, sizeof(title), "Pretty | %.1f/%.0f fps", 
+                 actual_fps, mode->refresh_rate);
         SDL_SetWindowTitle(win, title);
+
         last_time = current_time;
-        frames = 0;
+        frame_count = 0;
     }
 }
 
@@ -80,77 +82,111 @@ glyph_atlas *create_atlas(SDL_Renderer *renderer, TTF_Font *font, generic_config
         SDL_DestroySurface(s);
         SDL_DestroyTexture(t);
     }
+    int total_glyphs = 0;
+    for (int i = ' '; i <= '~'; i++) {
+        if (atlas->glyphs[i].w > 0) total_glyphs++;
+    }
+
+    pretty_log(PRETTY_INFO, "Atlas baked: %d glyphs. Cell size: %dx%d", 
+           total_glyphs, atlas->w, atlas->h);
 
     SDL_SetRenderTarget(renderer, NULL);
     return atlas;
 }
 
+void grid_resize(Grid *grid, int new_rows, int new_cols) {
+    Cell *new_cells = calloc(new_rows * new_cols, sizeof(Cell));
+    if (!new_cells) return;
+
+    int copy_rows = (new_rows < grid->rows) ? new_rows : grid->rows;
+    int copy_cols = (new_cols < grid->cols) ? new_cols : grid->cols;
+
+    for (int r = 0; r < copy_rows; r++) {
+        Cell *old_row_start = &grid->cells[r * grid->cols];
+        Cell *new_row_start = &new_cells[r * new_cols];
+        memcpy(new_row_start, old_row_start, copy_cols * sizeof(Cell));
+    }
+
+    free(grid->cells);
+    grid->cells = new_cells;
+    grid->rows = new_rows;
+    grid->cols = new_cols;
+}
+
+
+void rebuild_grid_from_buffer(Grid *grid, term *pretty, char *ring_buffer, size_t ring_size) {
+    memset(grid->cells, 0, grid->rows * grid->cols * sizeof(Cell));
+
+    int row = 0;
+    int col = 0;
+    size_t pos = pretty->scroll_tail;
+
+    while (pos != pretty->head && row < grid->rows) {
+        char ch = ring_buffer[pos];
+
+        if (ch == '\n') {
+            row++;
+            col = 0;
+        } else if (ch == '\r') {
+            col = 0;
+        } else if (ch == '\b' || ch == 0x7f) {
+            if (col > 0) {
+                col--;
+                grid->cells[row * grid->cols + col].ch = ' ';
+            } else if (row > 0) {
+                row--;
+                col = grid->cols - 1;
+                grid->cells[row * grid->cols + col].ch = ' ';
+            }
+        } else if (ch >= ' ' && ch <= '~') {
+            if (col >= grid->cols) {
+                row++;
+                col = 0;
+                if (row >= grid->rows) break;
+            }
+
+            grid->cells[row * grid->cols + col].ch = ch;
+            col++;
+        }
+        pos = (pos + 1) % ring_size;
+    }
+
+    pretty->cursor_row = row;
+    pretty->cursor_col = col;
+}
+
 bool render_frame(
     SDL_Renderer *renderer,
     glyph_atlas *atlas,
-    struct dim win_size,
-    term *pretty,
-    char *text,
-    size_t buff_size,
-    size_t *buff_pos,
-    font_info *font,
+    Grid *grid,
     generic_config *conf)
 {
-    pthread_mutex_lock(&pretty->buffer_lock);
+    SDL_Color bg = {
+        HEX_TO_RGB(conf->color_palette[COLOR_BACKGROUND]),
+        .a = 255
+    };
 
-    SDL_Color bg = { HEX_TO_RGB(conf->color_palette[COLOR_BACKGROUND]), .a=255 };
     SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
-
     SDL_RenderClear(renderer);
 
-    unsigned int x = conf->pad_x;
-    unsigned int y = conf->pad_y;
+    for (int row = 0; row < grid->rows; row++) {
+        for (int col = 0; col < grid->cols; col++) {
+            Cell *c = &grid->cells[row * grid->cols + col];
 
-    size_t line_max_width = (win_size.width - (2 * x)) / font->advance;
-    size_t line_max_count= (win_size.height - (2 * y)) / font->line_skip;
+            if (c->ch == '\0' || c->ch == ' ') continue;
 
-    size_t pos = pretty->scroll_tail;
-    size_t line_count = 0;
+            SDL_FRect src = atlas->glyphs[(unsigned char)c->ch];
+            SDL_FRect dst = {
+                .x = col * atlas->w,
+                .y = row * atlas->h,
+                .w = atlas->w,
+                .h = atlas->h
+            };
 
-    while (pos != *buff_pos && line_count < line_max_count) {
-        size_t current_line_len = 0;
-
-        while (pos != *buff_pos
-            && text[pos] != '\n'
-            && current_line_len < line_max_width)
-        {
-            char c = text[pos];
-
-            if (isprint(c)) {
-                SDL_FRect src_rect = atlas->glyphs[(unsigned char)c];
-
-                SDL_FRect dst_rect = {
-                    (float)(x + (current_line_len * font->advance)),
-                    (float)y,
-                    (float)font->advance,
-                    (float)font->line_skip
-                };
-
-                SDL_RenderTexture(renderer, atlas->texture, &src_rect, &dst_rect);
-            }
-
-            current_line_len++;
-            pos = (pos + 1) % buff_size;
+            SDL_RenderTexture(renderer, atlas->texture, &src, &dst);
         }
-
-        if (pos != *buff_pos && text[pos] == '\n') pos = (pos + 1) % buff_size;
-
-        line_count++;
-
-        if (line_count < line_max_count) y += font->line_skip;
-
     }
 
-    if (pretty->auto_scroll && line_count >= line_max_count && pos != *buff_pos)
-        calculate_scroll_internal(pretty, SCROLL_DOWN);
-
     SDL_RenderPresent(renderer);
-    pthread_mutex_unlock(&pretty->buffer_lock);
-
     return true;
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -166,6 +166,9 @@ bool render_frame(
         .a = 255
     };
 
+    unsigned int x = conf->pad_x;
+    unsigned int y = conf->pad_y;
+
     SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
     SDL_RenderClear(renderer);
 
@@ -177,8 +180,8 @@ bool render_frame(
 
             SDL_FRect src = atlas->glyphs[(unsigned char)c->ch];
             SDL_FRect dst = {
-                .x = col * atlas->w,
-                .y = row * atlas->h,
+                .x = x + col * atlas->w,
+                .y = y + row * atlas->h,
                 .w = atlas->w,
                 .h = atlas->h
             };

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -2,10 +2,11 @@
     #define RENDERER_H
 
     #include <SDL3/SDL.h>
+    #include <SDL3/SDL_video.h>
 
     #include "font.h"
     #include "config.h"
-    #include "terminal.h"
+    #include "types.h"
 
 typedef struct {
     SDL_Texture *texture;
@@ -13,22 +14,31 @@ typedef struct {
     int w, h;
 } glyph_atlas;
 
+struct Cell {
+    unsigned char ch;
+    uint8_t fg;
+    uint8_t bg;
+};
+
+struct Grid {
+    int rows;
+    int cols;
+    Cell *cells;
+};
+
 struct dim {
     int width;
     int height;
 };
 
-void display_fps_metrics(SDL_Window *win);
+void display_fps_metrics(SDL_Window *win, const SDL_DisplayMode *mode);
 glyph_atlas* create_atlas(SDL_Renderer *renderer, TTF_Font *font, generic_config *conf);
+void grid_resize(Grid *grid, int new_rows, int new_cols);
+void rebuild_grid_from_buffer(Grid *grid, term *pretty, char *ring_buffer, size_t ring_size);
 bool render_frame(
     SDL_Renderer *renderer,
     glyph_atlas *atlas,
-    struct dim win_size,
-    term *pretty,
-    char *text,
-    size_t buff_size,
-    size_t *buff_pos,
-    font_info *font,
+    Grid *grid,
     generic_config *conf
 );
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -41,5 +41,7 @@ bool render_frame(
     Grid *grid,
     generic_config *conf
 );
+void notify_ui_flush(void);
+
 
 #endif // RENDERER_H

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -5,19 +5,7 @@
 
     #include "font.h"
     #include "config.h"
-    #include "slave.h"
-
-
-#define FOREACH_EVENT(EVENT) \
-        EVENT(SCROLL_UP)   \
-        EVENT(SCROLL_DOWN)  \
-
-#define GENERATE_ENUM(ENUM) ENUM,
-#define GENERATE_STRING(STRING) #STRING,
-
-enum event {
-    FOREACH_EVENT(GENERATE_ENUM)
-};
+    #include "terminal.h"
 
 typedef struct {
     SDL_Texture *texture;
@@ -36,20 +24,12 @@ bool render_frame(
     SDL_Renderer *renderer,
     glyph_atlas *atlas,
     struct dim win_size,
-    tty_state *tty,
+    term *pretty,
     char *text,
     size_t buff_size,
     size_t *buff_pos,
     font_info *font,
     generic_config *conf
 );
-void read_to_buff(
-    tty_state *tty,
-    char *buff,
-    size_t buff_size,
-    size_t *buff_pos
-);
-
-void calculate_scroll(tty_state *tty, enum event dir);
 
 #endif // RENDERER_H

--- a/src/slave.c
+++ b/src/slave.c
@@ -13,6 +13,7 @@
 #include <sys/wait.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include "pretty.h"
 #include "slave.h"
@@ -148,8 +149,11 @@ bool pty_read(term *pretty)
 {
     pty_session *pty = &pretty->pty;
 
-    struct pollfd pfd = { .fd = pty->master, .events = POLLIN };
-    int ret = poll(&pfd, 1, -1);
+    struct pollfd pfds[2] = {
+        { .fd = pty->master, .events = POLLIN },
+        { .fd = pty->wakeup_fd, .events = POLLIN },
+    };
+    int ret = poll(pfds, 2, -1);
 
     if (ret < 0) {
         if (errno == EINTR) {
@@ -160,15 +164,22 @@ bool pty_read(term *pretty)
         return false;
     }
 
+    if (pfds[1].revents & POLLIN) {
+        uint64_t dummy;
+        ssize_t n = read(pty->wakeup_fd, &dummy, sizeof(dummy));
+        if (n < 0) pretty_log(PRETTY_ERROR, "failed to read wakeupfd: %s", strerror(errno));
+        return false;
+    }
+
     if (ret == 0) return true;
 
-    if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+    if (pfds[0].revents & (POLLHUP | POLLERR | POLLNVAL)) {
         waitpid(pid, NULL, WNOHANG);
         pretty_log(PRETTY_INFO, "PTY(%d) hangup or error", pty->master);
         return false;
     }
 
-    if (pfd.revents & POLLIN) {
+    if (pfds[0].revents & POLLIN) {
         char temp[TTY_RING_CAP];
         ssize_t n = read(pty->master, temp, sizeof temp);
 

--- a/src/slave.c
+++ b/src/slave.c
@@ -1,8 +1,9 @@
+#define _XOPEN_SOURCE 600
+
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <poll.h>
-#include <pty.h>
 #include <pwd.h>
 #include <signal.h>
 #include <stddef.h>
@@ -10,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include "pretty.h"
@@ -17,6 +19,7 @@
 #include "macro_utils.h"
 #include "pthread.h"
 #include "log.h"
+#include "terminal.h"
 
 static pid_t pid;
 
@@ -65,16 +68,31 @@ void exec_sh(char *args[static 1])
     exit(EXIT_FAILURE);
 }
 
-int tty_new(char *args[static 1])
+bool pty_pair(pty_session *pty)
 {
-    int cmdfd = -1;
-    int master;
-    int slave;
+    char *slave_name;
 
-    if (openpty(&master, &slave, NULL, NULL, NULL) < 0)
-        die("openpty call failed: %s", strerror(errno));
+    const int PTY_OPEN_FLAGS = O_RDWR | O_NOCTTY;
 
-    pretty_log(PRETTY_INFO, "Successfully opened a new tty");
+    pty->master = posix_openpt(PTY_OPEN_FLAGS);
+
+    if (pty->master < 0) die("openpty call failed: %s", strerror(errno));
+    if (grantpt(pty->master) == -1) die("failed to grantpt()");
+    if (unlockpt(pty->master) == -1) die("failed to unlockpt()");
+
+    slave_name = ptsname(pty->master);
+    if (slave_name == NULL) die("failed to ptsname()");
+
+    pty->slave = open(slave_name, PTY_OPEN_FLAGS);
+    if (pty->slave < 0) die("failed ot open slave");
+
+    pretty_log(PRETTY_INFO, "Successfully opened a new pty");
+
+    return true;
+}
+
+bool pty_init(pty_session *pty)
+{
 
     switch (pid = fork()) {
         case -1:
@@ -82,37 +100,37 @@ int tty_new(char *args[static 1])
             break;
         case 0:
             setsid();
-            dup2(slave, STDIN_FILENO);
-            dup2(slave, STDOUT_FILENO);
-            dup2(slave, STDERR_FILENO);
-            if (ioctl(slave, TIOCSCTTY, NULL) < 0)
+            dup2(pty->slave, STDIN_FILENO);
+            dup2(pty->slave, STDOUT_FILENO);
+            dup2(pty->slave, STDERR_FILENO);
+            if (ioctl(pty->slave, TIOCSCTTY, NULL) < 0)
                 die("ioctl TIOCSTTY failed: %s", strerror(errno));
 
-            if (slave > 2) close(slave);
+            if (pty->slave > 2) close(pty->slave);
 
-            exec_sh(args);
-            break;
+            exec_sh((char *[]){ "/bin/sh", NULL });
+            return false;
         default:
-            close(slave);
-            cmdfd = master;
+            close(pty->slave);
             signal(SIGCHLD, sigchld);
-            break;
+            return true;
     }
 
-    return cmdfd;
+    perror("fork");
+    return false;
 }
 
 static
-void tty_write_raw(tty_state *tty, const char *s, size_t n)
+void pty_write_raw(pty_session *pty, const char *s, size_t n)
 {
     ssize_t r;
 
     while (n > 0) {
-        r = write(tty->pty_master_fd, s, n);
+        r = write(pty->master, s, n);
 
         if (r < 0) {
             if (errno == EINTR || errno == EAGAIN) continue;
-            die("write error on tty: %s", strerror(errno));
+            die("write error on pty: %s", strerror(errno));
         }
 
         n -= r;
@@ -120,7 +138,7 @@ void tty_write_raw(tty_state *tty, const char *s, size_t n)
     }
 }
 
-void tty_write(tty_state *tty, const char *s, size_t n)
+void pty_write(pty_session *pty, const char *s, size_t n)
 {
     const char *next;
 
@@ -128,133 +146,73 @@ void tty_write(tty_state *tty, const char *s, size_t n)
     while (n > 0) {
         if (*s == '\r') {
             next = s + 1;
-            tty_write_raw(tty, "\r", 1);
+            pty_write_raw(pty, "\r", 1);
         } else {
             next = memchr(s, '\r', n);
             default_value(next, s + n);
-            tty_write_raw(tty, s, next - s);
+            pty_write_raw(pty, s, next - s);
         }
         n -= next - s;
         s = next;
     }
 }
 
-static
-inline size_t ring_count(const tty_state *tty)
-{
-    return (tty->head >= tty->tail)
-        ? (tty->head - tty->tail)
-        : (TTY_RING_CAP - (tty->tail - tty->head));
-}
 
 static
-size_t ring_write(tty_state *tty, const char *src, size_t nbytes)
+bool pty_read(term *pretty)
 {
-    size_t space = TTY_RING_CAP - 1 - ring_count(tty);
+    pty_session *pty = &pretty->pty;
 
-    if (nbytes > space) {
-        // drop excess
-        if (!tty->overwrite_oldest) nbytes = space;
-
-        // advance tail to free necessary bytes
-        else {
-            size_t fneed = nbytes - space;
-            tty->tail = (tty->tail + fneed) % TTY_RING_CAP;
-        };
-    }
-
-    // split copy across end if needed
-    size_t first = nbytes;
-    size_t end_space = TTY_RING_CAP - tty->head;
-
-    if (first > end_space) first = end_space;
-
-    memcpy(tty->buff + tty->head, src, first);
-    memcpy(tty->buff, src + first, nbytes - first);
-
-    tty->last_head = tty->head;
-    tty->head = (tty->head + nbytes) % TTY_RING_CAP;
-
-    return nbytes;
-}
-
-static
-bool tty_update(tty_state *tty)
-{
-    struct pollfd pfd = { .fd = tty->pty_master_fd, .events = POLLIN };
-    int ret = poll(&pfd, 1, 100);
+    struct pollfd pfd = { .fd = pty->master, .events = POLLIN };
+    int ret = poll(&pfd, 1, -1);
 
     if (ret < 0) {
-        if (errno == EINTR) return true;
+        if (errno == EINTR) {
+            if (pretty->pty.should_exit) return false;
+            return true;
+        }
         perror("poll");
         return false;
     }
 
     if (ret == 0) return true;
 
-    if (pfd.revents & (POLLHUP | POLLERR)) {
-        pretty_log(PRETTY_INFO, "TTY(%d) hangup or error", tty->pty_master_fd);
+    if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+        pretty_log(PRETTY_INFO, "PTY(%d) hangup or error", pty->master);
         return false;
     }
 
     if (pfd.revents & POLLIN) {
         char temp[TTY_RING_CAP];
-        ssize_t n = read(tty->pty_master_fd, temp, sizeof temp);
+        ssize_t n = read(pty->master, temp, sizeof temp);
 
         if (n > 0) {
-            pthread_mutex_lock(&tty->lock);
-
-            size_t wrote = ring_write(tty, temp, (size_t)n);
-
-            if (wrote < (size_t)n)
-                pretty_log(PRETTY_DEBUG, "Ring %s: replaced %zu oldest bytes",
-                           tty->overwrite_oldest ? "Overwrite" : "Dropped",
-                           (size_t)n - wrote);
-
-            if (!tty->buff_changed) (tty->buff_changed = true, notify_ui_flush());
-
-            pthread_mutex_unlock(&tty->lock);
+            pthread_mutex_lock(&pretty->buffer_lock);
+            ring_update(pretty, temp, (size_t)n);
+            pthread_mutex_unlock(&pretty->buffer_lock);
         } else if (n < 0 && errno == EIO) perror("read");
     }
 
     return true;
 }
 
-void *tty_poll_loop(void *arg)
+void *pty_poll_loop(void *arg)
 {
-    tty_state *tty = arg;
+    term *pretty = arg;
 
-    while (!tty->should_exit) {
-        if ((tty->child_exited = !tty_update(tty))) break;
-
-        pthread_mutex_lock(&tty->lock);
-        if (tty->buff_changed && tty->tail < tty->head) {
-            notify_ui_flush();
-            tty->buff_changed = false;
+    while (!pretty->pty.should_exit) {
+        if (!pty_read(pretty)) {
+            pretty->pty.child_exited = true;
+            break;
         }
-        pthread_mutex_unlock(&tty->lock);
+
+        pthread_mutex_lock(&pretty->buffer_lock);
+        if (pretty->buff_changed) {
+            notify_ui_flush();
+            pretty->buff_changed = false;
+        }
+        pthread_mutex_unlock(&pretty->buffer_lock);
     }
+
     return NULL;
-}
-
-
-size_t ring_read_span(const tty_state *tty, const char **ptr)
-{
-    size_t cont = ring_count(tty);
-    if (!cont) { *ptr = NULL; return 0; }
-
-    size_t end_contig = (tty->head >= tty->tail)
-        ? (tty->head - tty->tail)
-        : (TTY_RING_CAP - tty->tail);
-
-    *ptr = tty->buff + tty->tail;
-    return end_contig;
-}
-
-void ring_consume(tty_state *tty, size_t k)
-{
-    size_t cont = ring_count(tty);
-    if (k > cont) k = cont;
-
-    tty->tail = (tty->tail + k) % TTY_RING_CAP;
 }

--- a/src/slave.c
+++ b/src/slave.c
@@ -24,20 +24,6 @@
 static pid_t pid;
 
 static
-void sigchld(int a)
-{
-    int stat;
-    pid_t p = waitpid(pid, &stat, WNOHANG);
-
-    if (p < 0) die("waiting for pid %hd failed: %s", pid, strerror(errno));
-
-    if (p == 0 || pid != p) return;
-
-    if (WIFEXITED(stat) && WEXITSTATUS(stat)) die("child exited with status %d", WEXITSTATUS(stat));
-    else if (WIFSIGNALED(stat)) die("child terminated due to signal %d", WTERMSIG(stat));
-}
-
-static
 void exec_sh(char *args[static 1])
 {
     const struct passwd *pw;
@@ -112,7 +98,6 @@ bool pty_init(pty_session *pty)
             return false;
         default:
             close(pty->slave);
-            signal(SIGCHLD, sigchld);
             return true;
     }
 
@@ -178,6 +163,7 @@ bool pty_read(term *pretty)
     if (ret == 0) return true;
 
     if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+        waitpid(pid, NULL, WNOHANG);
         pretty_log(PRETTY_INFO, "PTY(%d) hangup or error", pty->master);
         return false;
     }

--- a/src/slave.c
+++ b/src/slave.c
@@ -22,6 +22,7 @@
 #include "pthread.h"
 #include "log.h"
 #include "terminal.h"
+#include "renderer.h"
 
 static pid_t pid;
 

--- a/src/slave.c
+++ b/src/slave.c
@@ -14,6 +14,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <SDL3/SDL.h>
 
 #include "pretty.h"
 #include "slave.h"
@@ -195,7 +196,11 @@ bool pty_read(term *pretty)
 
 void *pty_poll_loop(void *arg)
 {
-    term *pretty = arg;
+    thread_args *args = (thread_args *)arg;;
+    term *pretty = args->pretty;
+
+    const uint64_t MIN_NOTIFY_INTERVAL_MS = args->notify_interval;
+    uint64_t last_notify = 0;
 
     while (!pretty->pty.should_exit) {
         if (!pty_read(pretty)) {
@@ -205,8 +210,12 @@ void *pty_poll_loop(void *arg)
 
         pthread_mutex_lock(&pretty->buffer_lock);
         if (pretty->buff_changed) {
-            notify_ui_flush();
-            pretty->buff_changed = false;
+            uint64_t now = SDL_GetTicks();
+            if (now - last_notify >= MIN_NOTIFY_INTERVAL_MS) {
+                notify_ui_flush();
+                last_notify = now;
+                pretty->buff_changed = false;
+            }
         }
         pthread_mutex_unlock(&pretty->buffer_lock);
     }

--- a/src/slave.h
+++ b/src/slave.h
@@ -10,6 +10,7 @@ enum { TTY_RING_CAP = 64 * 1024 };
 typedef struct {
     int master;
     int slave;
+    int wakeup_fd;
 
     pthread_t thread;
     pthread_mutex_t io_lock;

--- a/src/slave.h
+++ b/src/slave.h
@@ -4,44 +4,23 @@
     #include <pthread.h>
     #include <stdbool.h>
     #include <stddef.h>
-    #include <stdio.h>
-
-enum term_mode {
-    MODE_WRAP        = 1 << 0,
-    MODE_INSERT      = 1 << 1,
-    MODE_ALTSCREEN   = 1 << 2,
-    MODE_CRLF        = 1 << 3,
-    MODE_ECHO        = 1 << 4,
-    MODE_PRINT       = 1 << 5,
-    MODE_UTF8        = 1 << 6,
-};
 
 enum { TTY_RING_CAP = 64 * 1024 };
 
 typedef struct {
-    int pty_master_fd;
-
-    char buff[TTY_RING_CAP]; /* TODO: think about this */
-    size_t head;
-    size_t last_head;
-    size_t tail;
-    size_t scroll_tail;
+    int master;
+    int slave;
 
     pthread_t thread;
-    pthread_mutex_t lock;
+    pthread_mutex_t io_lock;
 
     bool child_exited;
-    bool buff_changed;
     bool should_exit;
-    bool auto_scroll;
+} pty_session;
 
-    bool overwrite_oldest;
-} tty_state;
-
-int tty_new(char *args[static 1]);
-void *tty_poll_loop(void *arg);
-void tty_write(tty_state *tty, const char *s, size_t n);
-size_t ring_read_span(const tty_state *tty, const char **ptr);
-void ring_consume(tty_state *tty, size_t k);
+bool pty_pair(pty_session *pty);
+bool pty_init(pty_session *pty);
+void *pty_poll_loop(void *arg);
+void pty_write(pty_session *pty, const char *s, size_t n);
 
 #endif // SLAVE_H

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1,0 +1,183 @@
+#include <ctype.h>
+#include <string.h>
+#include "terminal.h"
+#include "log.h"
+
+static const char *event_name[] = {
+    FOREACH_EVENT(GENERATE_STRING)
+};
+
+static
+inline size_t ring_count(const term *pretty)
+{
+    return (pretty->head >= pretty->tail)
+        ? (pretty->head - pretty->tail)
+        : (TTY_RING_CAP - (pretty->tail - pretty->head));
+}
+
+static
+size_t ring_write(term *pretty, const char *src, size_t nbytes)
+{
+    size_t space = TTY_RING_CAP - 1 - ring_count(pretty);
+
+    if (nbytes > space) {
+        // drop excess
+        if (!pretty->overwrite_oldest) nbytes = space;
+
+        // advance tail to free necessary bytes
+        else {
+            size_t fneed = nbytes - space;
+            pretty->tail = (pretty->tail + fneed) % TTY_RING_CAP;
+        };
+    }
+
+    // split copy across end if needed
+    size_t first = nbytes;
+    size_t end_space = TTY_RING_CAP - pretty->head;
+
+    if (first > end_space) first = end_space;
+
+    memcpy(pretty->buff + pretty->head, src, first);
+    memcpy(pretty->buff, src + first, nbytes - first);
+
+    pretty->last_head = pretty->head;
+    pretty->head = (pretty->head + nbytes) % TTY_RING_CAP;
+
+    return nbytes;
+}
+
+size_t ring_read_span(const term *pretty, const char **ptr)
+{
+    size_t cont = ring_count(pretty);
+    if (!cont) { *ptr = NULL; return 0; }
+
+    size_t end_contig = (pretty->head >= pretty->tail)
+        ? (pretty->head - pretty->tail)
+        : (TTY_RING_CAP - pretty->tail);
+
+    *ptr = pretty->buff + pretty->tail;
+    return end_contig;
+}
+
+void ring_consume(term *pretty, size_t k)
+{
+    size_t cont = ring_count(pretty);
+    if (k > cont) k = cont;
+
+    pretty->tail = (pretty->tail + k) % TTY_RING_CAP;
+}
+
+void ring_update(term *pretty, const char *src, size_t nbytes)
+{
+
+    size_t wrote = ring_write(pretty, src, nbytes);
+
+    if (wrote < (size_t)nbytes)
+        pretty_log(PRETTY_DEBUG, "Ring %s: replaced %zu oldest bytes",
+                   pretty->overwrite_oldest ? "Overwrite" : "Dropped",
+                   nbytes - wrote);
+
+    if (!pretty->buff_changed) pretty->buff_changed = true;
+}
+
+void calculate_scroll_internal(term *pretty, enum event dir)
+{
+    switch (dir) {
+        case SCROLL_UP: {
+            if (pretty->scroll_tail == 0) break;
+
+            size_t pos = (pretty->scroll_tail + TTY_RING_CAP - 1) % TTY_RING_CAP;
+
+            while (pos != 0 && pretty->buff[pos] != '\n')
+                pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
+
+            if (pretty->buff[pos] == '\n' && pos != 0) {
+                pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
+
+                while (pos != 0 && pretty->buff[pos] != '\n')
+                    pos = (pos + TTY_RING_CAP - 1) % TTY_RING_CAP;
+
+                if (pretty->buff[pos] == '\n') pos = (pos + 1) % TTY_RING_CAP;
+            }
+
+            pretty->scroll_tail = pos;
+
+            break;
+        }
+        case SCROLL_DOWN: {
+            if (pretty->scroll_tail == pretty->head) break;
+
+            size_t pos = pretty->scroll_tail;
+            while (pos != pretty->head && pretty->buff[pos] != '\n')
+                pos = (pos + 1) % TTY_RING_CAP;
+
+            if (pos != pretty->head && pretty->buff[pos] == '\n')
+                pos = (pos + 1) % TTY_RING_CAP;
+
+            if (pos != pretty->head) pretty->scroll_tail = pos;
+
+            break;
+        }
+        default:
+            pretty_log(PRETTY_ERROR, "unhandled scroll event %d", dir);
+            return;
+    }
+
+    pretty_log(PRETTY_DEBUG, "scroll: event=%s, tail=%zu head=%zu",
+            event_name[dir], pretty->scroll_tail, pretty->head);
+}
+
+void calculate_scroll(term *pretty, enum event dir)
+{
+    pthread_mutex_lock(&pretty->buffer_lock);
+    calculate_scroll_internal(pretty, dir);
+    pthread_mutex_unlock(&pretty->buffer_lock);
+}
+
+void read_to_buff(
+    term *pretty,
+    char *buff,
+    size_t buff_size,
+    size_t *buff_pos)
+{
+    pthread_mutex_lock(&pretty->buffer_lock);
+
+    const char *p;
+    size_t new_bytes = ring_read_span(pretty, &p);
+
+    if (new_bytes) {
+        pretty_log(PRETTY_INFO, "Processing %zu new bytes (consumed: %zu, total: %zu)",
+           new_bytes, pretty->tail, pretty->head);
+
+        for (size_t i = 0; i < new_bytes; i++) {
+            char ch = p[i];
+
+            if (ch == '\b' || ch == 0x7f) {
+                if (*buff_pos > 0) {
+                    (*buff_pos)--;
+                    pretty_log(PRETTY_INFO, "Backspace: removed char at position %zu", *buff_pos);
+                    buff[*buff_pos] = '\0';
+                }
+            } else if (*buff_pos < buff_size - 1) {
+                buff[(*buff_pos)++] = ch;
+                buff[*buff_pos] = '\0';
+                pretty_log(PRETTY_INFO, "Added char '%c' at position %zu",
+                    (isprint(ch)) ? ch : '?', *buff_pos - 1);
+            }
+
+            if (*buff_pos >= buff_size - 1) {
+                pretty_log(PRETTY_WARN, "buff_pos overflow, resseting");
+                *buff_pos = 0;
+            }
+        }
+        ring_consume(pretty, new_bytes);
+    }
+    pthread_mutex_unlock(&pretty->buffer_lock);
+}
+
+// TODO: What should go in here?
+// struct pty_session *term_init()
+// {
+//
+//     return term;
+// }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1,11 +1,8 @@
-#include <ctype.h>
 #include <string.h>
-#include "terminal.h"
-#include "log.h"
 
-static const char *event_name[] = {
-    FOREACH_EVENT(GENERATE_STRING)
-};
+#include "terminal.h"
+#include "renderer.h"
+#include "log.h"
 
 static
 inline size_t ring_count(const term *pretty)
@@ -101,30 +98,29 @@ void calculate_scroll_internal(term *pretty, enum event dir)
             }
 
             pretty->scroll_tail = pos;
-
             break;
         }
         case SCROLL_DOWN: {
             if (pretty->scroll_tail == pretty->head) break;
 
             size_t pos = pretty->scroll_tail;
-            while (pos != pretty->head && pretty->buff[pos] != '\n')
-                pos = (pos + 1) % TTY_RING_CAP;
+            while (pos != pretty->head && pretty->buff[pos] != '\n') {
+                pos++;
+                if (pos >= TTY_RING_CAP) pos = 0;
+            }
 
-            if (pos != pretty->head && pretty->buff[pos] == '\n')
-                pos = (pos + 1) % TTY_RING_CAP;
+            if (pos != pretty->head && pretty->buff[pos] == '\n') {
+                pos++;
+                if (pos >= TTY_RING_CAP) pos = 0;
+            }
 
             if (pos != pretty->head) pretty->scroll_tail = pos;
-
             break;
         }
         default:
             pretty_log(PRETTY_ERROR, "unhandled scroll event %d", dir);
             return;
     }
-
-    pretty_log(PRETTY_DEBUG, "scroll: event=%s, tail=%zu head=%zu",
-            event_name[dir], pretty->scroll_tail, pretty->head);
 }
 
 void calculate_scroll(term *pretty, enum event dir)
@@ -134,6 +130,7 @@ void calculate_scroll(term *pretty, enum event dir)
     pthread_mutex_unlock(&pretty->buffer_lock);
 }
 
+static
 void read_to_buff(
     term *pretty,
     char *buff,
@@ -146,35 +143,71 @@ void read_to_buff(
     size_t new_bytes = ring_read_span(pretty, &p);
 
     if (new_bytes) {
-        pretty_log(PRETTY_INFO, "Processing %zu new bytes (consumed: %zu, total: %zu)",
-           new_bytes, pretty->tail, pretty->head);
-
         for (size_t i = 0; i < new_bytes; i++) {
             char ch = p[i];
-
-            if (ch == '\b' || ch == 0x7f) {
-                if (*buff_pos > 0) {
-                    (*buff_pos)--;
-                    pretty_log(PRETTY_INFO, "Backspace: removed char at position %zu", *buff_pos);
-                    buff[*buff_pos] = '\0';
-                }
-            } else if (*buff_pos < buff_size - 1) {
+            if (*buff_pos < buff_size - 1) {
                 buff[(*buff_pos)++] = ch;
                 buff[*buff_pos] = '\0';
-                pretty_log(PRETTY_INFO, "Added char '%c' at position %zu",
-                    (isprint(ch)) ? ch : '?', *buff_pos - 1);
             }
 
-            if (*buff_pos >= buff_size - 1) {
-                pretty_log(PRETTY_WARN, "buff_pos overflow, resseting");
-                *buff_pos = 0;
-            }
+            if (*buff_pos >= buff_size - 1) *buff_pos = 0;
         }
         ring_consume(pretty, new_bytes);
     }
     pthread_mutex_unlock(&pretty->buffer_lock);
 }
 
+void process_buffer(term *pretty, Grid *grid, char *buff, size_t *buff_pos, size_t buff_size)
+{
+    size_t i = *buff_pos;
+    read_to_buff(pretty, buff, buff_size, buff_pos);
+
+    bool is_at_end = (pretty->scroll_tail == pretty->last_head);
+
+    for (; i < *buff_pos; i++) {
+        unsigned char ch = buff[i];
+
+        if (ch == '\b' || ch == 0x7f) {
+            if (pretty->cursor_col > 0) {
+                pretty->cursor_col--;
+            } else if (pretty->cursor_row > 0) {
+                pretty->cursor_row--;
+                pretty->cursor_col = grid->cols - 1;
+            }
+
+            Cell *cell = &grid->cells[pretty->cursor_row * grid->cols + pretty->cursor_col];
+            cell->ch = ' ';
+            continue;
+        }
+
+        if (ch == '\n') {
+            pretty->cursor_row++;
+            pretty->cursor_col = 0;
+            continue;
+        } else if (ch == '\r') {
+            pretty->cursor_col = 0;
+            continue;
+        }
+
+        if (pretty->cursor_col >= grid->cols) {
+            pretty->cursor_col = 0;
+            pretty->cursor_row++;
+        }
+        if (pretty->cursor_row >= grid->rows) {
+           calculate_scroll(pretty, SCROLL_DOWN);
+           pretty->cursor_row = grid->rows - 1;
+        }
+
+        Cell *cell = &grid->cells[pretty->cursor_row * grid->cols + pretty->cursor_col];
+        cell->ch = (char)ch;
+
+        pretty->cursor_col++;
+    }
+
+    *buff_pos = 0;
+
+    if (!is_at_end) rebuild_grid_from_buffer(grid, pretty, pretty->buff, TTY_RING_CAP);
+}
 // TODO: What should go in here?
 // struct pty_session *term_init()
 // {

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -1,0 +1,54 @@
+#ifndef TERMINAL_H
+    #define TERMINAL_H
+
+    #include "slave.h"
+
+#define FOREACH_EVENT(EVENT) \
+        EVENT(SCROLL_UP)   \
+        EVENT(SCROLL_DOWN)  \
+
+#define GENERATE_ENUM(ENUM) ENUM,
+#define GENERATE_STRING(STRING) #STRING,
+
+enum event {
+    FOREACH_EVENT(GENERATE_ENUM)
+};
+
+enum term_mode {
+    MODE_WRAP        = 1 << 0,
+    MODE_INSERT      = 1 << 1,
+    MODE_ALTSCREEN   = 1 << 2,
+    MODE_CRLF        = 1 << 3,
+    MODE_ECHO        = 1 << 4,
+    MODE_PRINT       = 1 << 5,
+    MODE_UTF8        = 1 << 6,
+};
+
+typedef struct {
+    pty_session pty;
+
+    char buff[TTY_RING_CAP]; /* TODO: think about this */
+    size_t head;
+    size_t last_head;
+    size_t tail;
+    size_t scroll_tail;
+
+    pthread_mutex_t buffer_lock;
+    bool buff_changed;
+    bool overwrite_oldest;
+    bool auto_scroll;
+} term;
+
+size_t ring_read_span(const term *pretty, const char **ptr);
+void ring_consume(term *pretty, size_t k);
+void ring_update(term *pretty, const char *src, size_t nbytes);
+void calculate_scroll_internal(term *pretty, enum event dir);
+void calculate_scroll(term *pretty, enum event dir);
+void read_to_buff(
+    term *pretty,
+    char *buff,
+    size_t buff_size,
+    size_t *buff_pos
+);
+
+#endif // TERMINAL_H

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -2,6 +2,7 @@
     #define TERMINAL_H
 
     #include "slave.h"
+    #include "types.h"
 
 #define FOREACH_EVENT(EVENT) \
         EVENT(SCROLL_UP)   \
@@ -24,7 +25,7 @@ enum term_mode {
     MODE_UTF8        = 1 << 6,
 };
 
-typedef struct {
+struct term {
     pty_session pty;
 
     char buff[TTY_RING_CAP]; /* TODO: think about this */
@@ -32,23 +33,19 @@ typedef struct {
     size_t last_head;
     size_t tail;
     size_t scroll_tail;
+    int cursor_col;
+    int cursor_row;
 
     pthread_mutex_t buffer_lock;
     bool buff_changed;
     bool overwrite_oldest;
-    bool auto_scroll;
-} term;
+};
 
 size_t ring_read_span(const term *pretty, const char **ptr);
 void ring_consume(term *pretty, size_t k);
 void ring_update(term *pretty, const char *src, size_t nbytes);
 void calculate_scroll_internal(term *pretty, enum event dir);
 void calculate_scroll(term *pretty, enum event dir);
-void read_to_buff(
-    term *pretty,
-    char *buff,
-    size_t buff_size,
-    size_t *buff_pos
-);
+void process_buffer(term *pretty, Grid *grid, char *buff, size_t *buff_pos, size_t buff_size);
 
 #endif // TERMINAL_H

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,8 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+typedef struct term term;
+typedef struct Grid Grid;
+typedef struct Cell Cell;
+
+#endif


### PR DESCRIPTION
- Implement manual PTY setup via `posix_openpt`, `grantpt`, and `unlockpt`.
- Introduce `pty_session` and `term` structs to separate I/O from state.
- Replace the `100ms` poll timeout with an infinite block, using `pthread_kill(SIGUSR1)` for clean thread teardown.
- Move buffer management and scrolling logic out of `renderer.c`.
- Split monolithic `tty->lock` into `io_lock` and `buffer_lock` for finer granularity.