### PR TITLE
Improve logging logic

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -10,11 +10,15 @@
 char *pretty_log_get_time(void)
 {
     static char timebuf[16];
-    time_t now = time(NULL);
-    struct tm local;
-    localtime_r(&now, &local);
+    static time_t last = 0;
 
-    strftime(timebuf, sizeof(timebuf), "%H:%M:%S", &local);
+    time_t now = time(NULL);
+    if (now != last) {
+        last = now;
+        struct tm local;
+        localtime_r(&now, &local);
+        strftime(timebuf, sizeof(timebuf), "%H:%M:%S", &local);
+    }
 
     return timebuf;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -24,7 +24,7 @@ void pretty_log_full(enum log_level level, const char *text, ...)
     static pthread_mutex_t log_mutex = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_lock(&log_mutex);
 
-    char message[BUFSIZ - 64];
+    char message[BUFSIZ];
 
     va_list args;
     va_start(args, text);

--- a/src/log.h
+++ b/src/log.h
@@ -16,12 +16,20 @@ char *pretty_log_get_time(void);
 #ifdef DEBUG_MODE
     #define LOG_HEAD "[%s | %s] @ %s:%d: "
     #define LOG_HEAD_ARGS(lvl) pretty_log_get_time(), #lvl, __FILE__, __LINE__
+    #define pretty_log(lvl, msg, ...)               \
+        do {                                        \
+            pretty_log_full(lvl, LOG_HEAD msg,      \
+                LOG_HEAD_ARGS(lvl), ##__VA_ARGS__); \
+        } while (0)
 #else
     #define LOG_HEAD "[%s | %s]: "
     #define LOG_HEAD_ARGS(lvl) pretty_log_get_time(), #lvl
+    #define pretty_log(lvl, msg, ...)                   \
+        do {                                            \
+            if ((lvl) != PRETTY_DEBUG)                  \
+                pretty_log_full(lvl, LOG_HEAD msg,      \
+                    LOG_HEAD_ARGS(lvl), ##__VA_ARGS__); \
+        } while (0)
 #endif
-
-#define pretty_log(lvl, msg, ...) \
-    pretty_log_full(lvl, LOG_HEAD msg, LOG_HEAD_ARGS(lvl), ##__VA_ARGS__)
 
 #endif // LOG_H


### PR DESCRIPTION
We had cases where we wanted to debug code using the `pretty_log` system. Our logging levels are defined as:

```c
enum log_level {
    PRETTY_ERROR,
    PRETTY_WARN,
    PRETTY_INFO,
    PRETTY_DEBUG
};
```

The main issue was that `PRETTY_DEBUG` logs were still emitted in `RELEASE` builds.

> Note: Logging can be expensive, and unnecessary debug statements can significantly impact the emulator’s performance.

This PR introduces two commits:

1. **Compile-time debug filtering**:
   Using the C preprocessor, `PRETTY_DEBUG` logs are only included when the binary is built with `DEBUG_MODE`. This ensures debug logs are removed from release builds entirely.

2. **Time caching optimization**:
   `pretty_log_get_time()` now caches the last retrieved time (`time_t last`) and only updates when the current time (`time_t now`) changes. This eliminates redundant syscalls, reducing overhead in frequent logging scenarios.